### PR TITLE
feat: add customer lifetime value model for retention campaigns

### DIFF
--- a/dbt_project/models/marts/_mart_models.yml
+++ b/dbt_project/models/marts/_mart_models.yml
@@ -50,3 +50,33 @@ models:
         tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'returned']
+
+  - name: fct_customer_lifetime_value
+    description: "Customer lifetime value metrics for retention campaign targeting"
+    columns:
+      - name: customer_id
+        description: "Primary key — unique customer identifier"
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_id
+      - name: email
+        description: "Masked customer email for campaign targeting"
+      - name: lifetime_spend
+        description: "Total spend across all orders"
+        tests:
+          - not_null
+      - name: total_orders
+        description: "Count of all orders placed"
+        tests:
+          - not_null
+      - name: avg_order_value
+        description: "Average payment amount per order"
+        tests:
+          - not_null
+      - name: days_since_first_order
+        description: "Days between first order and today"
+      - name: days_since_last_order
+        description: "Days between most recent order and today — churn risk indicator"

--- a/dbt_project/models/marts/fct_customer_lifetime_value.sql
+++ b/dbt_project/models/marts/fct_customer_lifetime_value.sql
@@ -1,0 +1,39 @@
+with customer_orders as (
+    select * from {{ ref('int_customer_orders') }}
+),
+
+payment_totals as (
+    select * from {{ ref('int_payment_totals') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customer_payments as (
+    select
+        orders.customer_id,
+        sum(payment_totals.total_amount) as lifetime_spend,
+        count(distinct orders.order_id) as total_orders,
+        avg(payment_totals.total_amount) as avg_order_value
+    from orders
+    left join payment_totals on orders.order_id = payment_totals.order_id
+    group by orders.customer_id
+),
+
+final as (
+    select
+        customer_orders.customer_id,
+        customer_orders.first_name,
+        customer_orders.last_name,
+        {{ mask_pii('customer_orders.email') }} as email,
+        coalesce(customer_payments.lifetime_spend, 0) as lifetime_spend,
+        coalesce(customer_payments.total_orders, 0) as total_orders,
+        coalesce(customer_payments.avg_order_value, 0) as avg_order_value,
+        datediff('day', customer_orders.first_order_date, current_date()) as days_since_first_order,
+        datediff('day', customer_orders.most_recent_order_date, current_date()) as days_since_last_order
+    from customer_orders
+    left join customer_payments on customer_orders.customer_id = customer_payments.customer_id
+)
+
+select * from final


### PR DESCRIPTION
## Summary
- Adds `fct_customer_lifetime_value` to the marts layer with CLV metrics (lifetime_spend, total_orders, avg_order_value, churn risk indicators)
- Email column masked via `mask_pii()` macro for governance compliance
- Includes full schema YAML with uniqueness, not-null, and relationship tests

Closes #1

## Test plan
- [ ] CI/CD pipeline passes (dbt build succeeds with all tests)
- [ ] `fct_customer_lifetime_value` table created in `ECOM_ANALYTICS.MARTS`
- [ ] Email masking verified — non-PII_ALLOWED roles see `***@domain.com`
- [ ] Relationship test confirms all customer_ids exist in `dim_customers`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)