### PR TITLE
Add customer lifetime value model with segmentation

### DIFF
--- a/dbt_project/models/marts/_mart_models.yml
+++ b/dbt_project/models/marts/_mart_models.yml
@@ -50,3 +50,53 @@ models:
         tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'returned']
+
+  - name: fct_customer_lifetime_value
+    description: >
+      Customer lifetime value model with 4-tier segmentation for the Q2 retention campaign.
+      Combines order history, payment data, and customer details. PII columns are masked
+      via mask_pii() macro. days_since_* columns are point-in-time — values reflect the
+      last dbt build, not real-time.
+    columns:
+      - name: customer_id
+        description: "Primary key — unique customer identifier"
+        tests:
+          - unique
+          - not_null
+      - name: customer_name
+        description: "First and last name concatenated. Masked for non-PII_ALLOWED roles."
+      - name: email
+        description: "Customer email for campaign targeting. Masked for non-PII_ALLOWED roles."
+        tests:
+          - not_null
+      - name: first_order_date
+        description: "Date of the customer's first order"
+      - name: most_recent_order_date
+        description: "Date of the customer's most recent order"
+      - name: number_of_orders
+        description: "Total distinct orders placed by the customer"
+        tests:
+          - not_null
+      - name: lifetime_spend
+        description: "Sum of all payment amounts across all orders"
+        tests:
+          - not_null
+      - name: avg_order_value
+        description: "Average total payment per order (handles split payments via int_payment_totals)"
+        tests:
+          - not_null
+      - name: days_since_first_order
+        description: "Days between first order and the dbt build date — stale between refreshes"
+      - name: days_since_last_order
+        description: "Days between most recent order and the dbt build date — used for churn risk"
+      - name: preferred_payment_method
+        description: "Payment method used most frequently by the customer (by count, not recency)"
+      - name: customer_segment
+        description: >
+          4-tier classification: VIP (≥$500 spend, ordered ≤90 days), Regular (≥$200, ≤90 days),
+          At-Risk (≥$200, >90 days — primary campaign targets), New (all others).
+          Segment is point-in-time and may shift between builds.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['VIP', 'Regular', 'At-Risk', 'New']

--- a/dbt_project/models/marts/_mart_models.yml
+++ b/dbt_project/models/marts/_mart_models.yml
@@ -65,8 +65,12 @@ models:
           - not_null
       - name: customer_name
         description: "First and last name concatenated. Masked for non-PII_ALLOWED roles."
+        meta:
+          data_classification: "PII - Personal Identifier"
       - name: email
         description: "Customer email for campaign targeting. Masked for non-PII_ALLOWED roles."
+        meta:
+          data_classification: "PII - Personal Identifier"
         tests:
           - not_null
       - name: first_order_date

--- a/dbt_project/models/marts/fct_customer_lifetime_value.sql
+++ b/dbt_project/models/marts/fct_customer_lifetime_value.sql
@@ -1,0 +1,98 @@
+with customer_orders as (
+    select * from {{ ref('int_customer_orders') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payment_totals as (
+    select * from {{ ref('int_payment_totals') }}
+),
+
+payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+-- Aggregate lifetime spend per customer using int_payment_totals
+customer_spend as (
+    select
+        orders.customer_id,
+        sum(payment_totals.total_amount) as lifetime_spend,
+        avg(payment_totals.total_amount) as avg_order_value
+    from orders
+    left join payment_totals on orders.order_id = payment_totals.order_id
+    group by orders.customer_id
+),
+
+-- Derive preferred payment method by frequency per customer
+payment_frequency as (
+    select
+        orders.customer_id,
+        payments.payment_method,
+        count(*) as method_count,
+        row_number() over (
+            partition by orders.customer_id
+            order by count(*) desc, payments.payment_method
+        ) as rn
+    from orders
+    inner join payments on orders.order_id = payments.order_id
+    group by orders.customer_id, payments.payment_method
+),
+
+preferred_payment as (
+    select
+        customer_id,
+        payment_method as preferred_payment_method
+    from payment_frequency
+    where rn = 1
+),
+
+final as (
+    select
+        customer_orders.customer_id,
+        customer_orders.first_name || ' ' || customer_orders.last_name as customer_name_raw,
+        customer_orders.email as email_raw,
+        customer_orders.first_order_date,
+        customer_orders.most_recent_order_date,
+        customer_orders.number_of_orders,
+        coalesce(customer_spend.lifetime_spend, 0) as lifetime_spend,
+        coalesce(customer_spend.avg_order_value, 0) as avg_order_value,
+        datediff('day', customer_orders.first_order_date, current_date()) as days_since_first_order,
+        datediff('day', customer_orders.most_recent_order_date, current_date()) as days_since_last_order,
+        preferred_payment.preferred_payment_method,
+
+        -- 4-tier customer segmentation
+        -- Thresholds from Rebecca (Head of Marketing) via Lisa, confirmed 18 Feb 2026
+        case
+            when coalesce(customer_spend.lifetime_spend, 0) >= 500
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+                then 'VIP'
+            when coalesce(customer_spend.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+                then 'Regular'
+            when coalesce(customer_spend.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) > 90
+                then 'At-Risk'
+            else 'New'
+        end as customer_segment
+
+    from customer_orders
+    left join customer_spend on customer_orders.customer_id = customer_spend.customer_id
+    left join preferred_payment on customer_orders.customer_id = preferred_payment.customer_id
+)
+
+select
+    customer_id,
+    {{ mask_pii('customer_name_raw') }} as customer_name,
+    {{ mask_pii('email_raw') }} as email,
+    first_order_date,
+    most_recent_order_date,
+    number_of_orders,
+    lifetime_spend,
+    avg_order_value,
+    days_since_first_order,
+    days_since_last_order,
+    preferred_payment_method,
+    customer_segment
+from final

--- a/dbt_project/models/marts/fct_customer_lifetime_value.sql
+++ b/dbt_project/models/marts/fct_customer_lifetime_value.sql
@@ -26,6 +26,8 @@ customer_spend as (
 ),
 
 -- Derive preferred payment method by frequency per customer
+-- Uses stg_payments directly (not int_payment_totals) because we need per-payment-row
+-- granularity to count method frequency. int_payment_totals aggregates to order level.
 payment_frequency as (
     select
         orders.customer_id,


### PR DESCRIPTION
Adds fct_customer_lifetime_value mart model with 4-tier customer segmentation (VIP, Regular, At-Risk, New) for the Q2 retention campaign. PII masked via mask_pii(). Closes #1.