### PR TITLE
Add customer lifetime value model with segmentation

### DIFF
--- a/dbt_project/models/intermediate/_int_models.yml
+++ b/dbt_project/models/intermediate/_int_models.yml
@@ -22,3 +22,14 @@ models:
           - not_null
       - name: total_amount
         description: "Total payment amount for the order"
+
+  - name: int_customer_payment_methods
+    description: "Most frequently used payment method per customer, derived from payment count across all orders"
+    columns:
+      - name: customer_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: preferred_payment_method
+        description: "The payment method used most frequently by the customer (ties broken alphabetically)"

--- a/dbt_project/models/intermediate/int_customer_payment_methods.sql
+++ b/dbt_project/models/intermediate/int_customer_payment_methods.sql
@@ -1,0 +1,35 @@
+with payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+customer_payment_methods as (
+    select
+        orders.customer_id,
+        payments.payment_method,
+        count(*) as payment_count
+    from payments
+    inner join orders on payments.order_id = orders.order_id
+    group by orders.customer_id, payments.payment_method
+),
+
+ranked as (
+    select
+        customer_id,
+        payment_method,
+        payment_count,
+        row_number() over (
+            partition by customer_id
+            order by payment_count desc, payment_method
+        ) as rn
+    from customer_payment_methods
+)
+
+select
+    customer_id,
+    payment_method as preferred_payment_method
+from ranked
+where rn = 1

--- a/dbt_project/models/marts/_mart_models.yml
+++ b/dbt_project/models/marts/_mart_models.yml
@@ -50,3 +50,52 @@ models:
         tests:
           - accepted_values:
               values: ['placed', 'shipped', 'completed', 'returned']
+
+  - name: fct_customer_lifetime_value
+    description: >
+      Customer lifetime value model with spend metrics and segmentation for
+      the Q2 retention campaign. Segments classify customers into VIP, Regular,
+      At-Risk, and New tiers based on lifetime spend and recency thresholds.
+      Note: days_since_* columns and customer_segment are point-in-time values
+      computed at build time and will be stale between refreshes.
+    columns:
+      - name: customer_id
+        description: "Primary key — unique customer identifier"
+        tests:
+          - unique
+          - not_null
+      - name: customer_name
+        description: "Customer full name (first + last), masked for non-privileged roles"
+      - name: email
+        description: "Customer email address, masked for non-privileged roles via mask_pii()"
+      - name: lifetime_spend
+        description: "Total amount spent across all orders (sum of all payment amounts)"
+        tests:
+          - not_null
+      - name: total_orders
+        description: "Count of distinct orders placed by the customer"
+        tests:
+          - not_null
+      - name: average_order_value
+        description: "Average total payment per order (lifetime_spend / total_orders). Zero if no orders."
+        tests:
+          - not_null
+      - name: first_order_date
+        description: "Date of the customer's first order"
+      - name: most_recent_order_date
+        description: "Date of the customer's most recent order"
+      - name: days_since_first_order
+        description: "Days between first order and build date. Stale between refreshes."
+      - name: days_since_last_order
+        description: "Days between most recent order and build date. Churn risk indicator. Stale between refreshes."
+      - name: preferred_payment_method
+        description: "Payment method used most frequently by the customer across all orders"
+      - name: customer_segment
+        description: >
+          Customer segment classification: VIP (spend >= $500, ordered within 90 days),
+          Regular (spend >= $200, ordered within 90 days), At-Risk (spend >= $200,
+          no orders in 90 days), New (spend < $200). Point-in-time at build.
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['VIP', 'Regular', 'At-Risk', 'New']

--- a/dbt_project/models/marts/fct_customer_lifetime_value.sql
+++ b/dbt_project/models/marts/fct_customer_lifetime_value.sql
@@ -1,0 +1,67 @@
+with customer_orders as (
+    select * from {{ ref('int_customer_orders') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payment_totals as (
+    select * from {{ ref('int_payment_totals') }}
+),
+
+customer_payments as (
+    select
+        orders.customer_id,
+        sum(payment_totals.total_amount) as lifetime_spend,
+        count(distinct orders.order_id) as total_orders
+    from orders
+    left join payment_totals on orders.order_id = payment_totals.order_id
+    group by orders.customer_id
+),
+
+customer_payment_methods as (
+    select * from {{ ref('int_customer_payment_methods') }}
+),
+
+final as (
+    select
+        customer_orders.customer_id,
+        case
+            when is_role_in_session('PII_ALLOWED')
+            then customer_orders.first_name || ' ' || customer_orders.last_name
+            else '***'
+        end as customer_name,
+        {{ mask_pii('customer_orders.email') }} as email,
+        coalesce(customer_payments.lifetime_spend, 0) as lifetime_spend,
+        coalesce(customer_payments.total_orders, 0) as total_orders,
+        case
+            when customer_payments.total_orders > 0
+            then customer_payments.lifetime_spend / customer_payments.total_orders
+            else 0
+        end as average_order_value,
+        customer_orders.first_order_date,
+        customer_orders.most_recent_order_date,
+        datediff('day', customer_orders.first_order_date, current_date()) as days_since_first_order,
+        datediff('day', customer_orders.most_recent_order_date, current_date()) as days_since_last_order,
+        customer_payment_methods.preferred_payment_method,
+        case
+            when coalesce(customer_payments.lifetime_spend, 0) >= 500
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+            then 'VIP'
+            when coalesce(customer_payments.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+            then 'Regular'
+            when coalesce(customer_payments.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) > 90
+            then 'At-Risk'
+            else 'New'
+        end as customer_segment
+    from customer_orders
+    left join customer_payments
+        on customer_orders.customer_id = customer_payments.customer_id
+    left join customer_payment_methods
+        on customer_orders.customer_id = customer_payment_methods.customer_id
+)
+
+select * from final


### PR DESCRIPTION
## Summary
- Adds fct_customer_lifetime_value mart model with CLV metrics (lifetime spend, total orders, AOV, recency days) and four-tier customer segmentation (VIP, Regular, At-Risk, New) for the Q2 retention campaign
- Adds int_customer_payment_methods intermediate model to derive each customer's most frequently used payment method
- PII columns (email, customer_name) masked via mask_pii() macro and is_role_in_session('PII_ALLOWED')
- Full schema tests (PK uniqueness, not_null, accepted_values on segment) and column descriptions

Closes #1

## Test plan
- [ ] Verify int_customer_payment_methods returns one row per customer with correct preferred method
- [ ] Verify fct_customer_lifetime_value joins correctly through intermediate models (no direct raw/staging refs)
- [ ] Confirm segment thresholds match issue spec: VIP ($500+, 90d), Regular ($200+, 90d), At-Risk ($200+, >90d), New (<$200)
- [ ] Validate PII masking on email and customer_name columns for non-privileged roles
- [ ] Run dbt build — all schema tests pass (unique, not_null, accepted_values)
- [ ] Confirm materialization as table (inherited from marts config)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
