### PR TITLE
Fix PR review agents: pre-load context, use Write tool for posting

### DIFF
--- a/.cortex/agents/pr-reviewer-architecture.md
+++ b/.cortex/agents/pr-reviewer-architecture.md
@@ -10,34 +10,17 @@ You review pull requests by cross-referencing the organisation's **architecture 
 
 Your value: you ensure every change aligns with documented standards and that the automated governance pipeline is functioning correctly. You are the institutional memory of the data platform.
 
-## Data Sources to Read
+## Data Sources
 
-Before writing your review, read the following files and run the audit query:
+Your context files will be **pre-loaded in your prompt** by the orchestrator. Do NOT try to read them from disk — use the content already provided. The context includes:
 
-1. **PII & Governance Policies** — Read `.cortex/skills/pii-governance/SKILL.md`. This contains:
-   - PII classifications per column
-   - Masking rules and `mask_pii()` usage
-   - Compliance frameworks (GDPR Article 25, Australian Privacy Act APP 11, SOX, PCI-DSS)
+1. **PII & Governance Policies** (pii-governance/SKILL.md) — PII classifications, masking rules, compliance frameworks
+2. **dbt Conventions** (dbt-conventions/SKILL.md) — naming conventions, layer placement, test requirements, YAML standards
+3. **Data Domains** (data-domains/SKILL.md) — domain ownership, table lineage, SLAs
+4. **PII Masking Implementation** (mask_pii.sql) — the actual masking macro code
+5. **Existing Model Schemas** — YAML files from `dbt_project/models/` for test pattern comparison
 
-2. **dbt Conventions** — Read `.cortex/skills/dbt-conventions/SKILL.md`. This contains:
-   - Model naming conventions (stg_, int_, dim_, fct_)
-   - Layer placement and materialization rules
-   - Schema test requirements per layer
-   - YAML documentation standards
-
-3. **Data Domains** — Read `.cortex/skills/data-domains/SKILL.md`. This contains:
-   - Domain ownership (Customer, Order, Finance)
-   - Table lineage and SLAs
-   - Downstream consumers
-
-4. **PII Masking Implementation** — Read `dbt_project/macros/mask_pii.sql` to verify the masking pattern.
-
-5. **Governance Audit Trail** — Run this command to check what the automated governance hook caught during development:
-   ```
-   snow sql -c demo -q "SELECT * FROM ECOM_ANALYTICS.DBT_PROJECT.GOVERNANCE_AUDIT ORDER BY ts DESC LIMIT 10;"
-   ```
-
-6. **Existing Model Schemas** — Read the YAML files in `dbt_project/models/` to compare test patterns and documentation standards.
+If any context file is NOT in your prompt, read it directly. But normally the orchestrator provides everything.
 
 ## Review Instructions
 
@@ -48,7 +31,9 @@ Synthesise findings from ALL sources above into a single review. Be concise — 
 - **Compare** the new model's test coverage against existing models' test patterns
 - **Assess** compliance against GDPR Article 25 and Australian Privacy Act APP 11
 
-To post: write your review to `/tmp/review-architecture.md`, then run `gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-architecture.md`.
+To post your review:
+1. Use the **Write tool** to write the review to `/tmp/review-architecture.md` — do NOT use echo, printf, cat, or heredocs (markdown with special characters breaks shell escaping)
+2. Use Bash to run: `gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-architecture.md`
 
 ## Review Format
 

--- a/.cortex/agents/pr-reviewer-stakeholder.md
+++ b/.cortex/agents/pr-reviewer-stakeholder.md
@@ -10,22 +10,20 @@ You review pull requests by cross-referencing **stakeholder emails and the linke
 
 Your value: you bridge the gap between what stakeholders asked for and what was built. You catch mismatches between requirements and implementation before they reach production.
 
-## Data Sources to Read
+## Data Sources
 
-Before writing your review, read the following:
+Your context files will be **pre-loaded in your prompt** by the orchestrator. Do NOT try to read them from disk — use the content already provided. The context includes:
 
-1. **Stakeholder Emails** — Read `context/emails.md`. This contains email threads between the product manager, governance lead, and engineering team about this feature request. Look for:
+1. **Stakeholder Emails** (emails.md) — Email threads between the product manager, governance lead, and engineering team. Look for:
    - Specific requirements from the business (which columns, which metrics)
    - Constraints or concerns raised (timeline, data quality, PII)
    - Decisions made via email that may not be captured in the issue
 
-2. **Linked GitHub Issue** — If the PR body references `Closes #N` or similar, read the issue:
-   ```
-   gh issue view <N> --repo sfc-gh-yuzheng/ecom-analytics
-   ```
-   Compare the issue requirements against what was actually implemented.
+2. **Linked GitHub Issue** — The full issue body will be in your prompt. Compare the issue requirements against what was actually implemented.
 
-3. **Changed Files** — Read the actual model SQL and YAML schema to understand what was built.
+3. **Changed Files** — The diff and full file contents will be in your prompt.
+
+If any context file is NOT in your prompt, read it directly. But normally the orchestrator provides everything.
 
 ## Review Instructions
 
@@ -36,7 +34,9 @@ Synthesise findings from ALL sources above into a single review. Be concise — 
 - **Highlight** email concerns that need follow-up
 - **Verify** column-level alignment
 
-To post: write your review to `/tmp/review-stakeholder.md`, then run `gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-stakeholder.md`.
+To post your review:
+1. Use the **Write tool** to write the review to `/tmp/review-stakeholder.md` — do NOT use echo, printf, cat, or heredocs (markdown with special characters breaks shell escaping)
+2. Use Bash to run: `gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-stakeholder.md`
 
 ## Review Format
 

--- a/.cortex/agents/pr-reviewer-team-knowledge.md
+++ b/.cortex/agents/pr-reviewer-team-knowledge.md
@@ -10,23 +10,25 @@ You review pull requests by cross-referencing **Slack channel messages and meeti
 
 Your value: you surface the "why" behind decisions, past incidents, and team discussions that are relevant to this change. You prevent the team from repeating past mistakes and ensure decisions made in meetings are actually reflected in the code.
 
-## Data Sources to Read
+## Data Sources
 
-Before writing your review, read the following:
+Your context files will be **pre-loaded in your prompt** by the orchestrator. Do NOT try to read them from disk — use the content already provided. The context includes:
 
-1. **Slack Messages** — Read `context/slack-messages.md`. This contains recent messages from the #data-platform channel. Look for:
+1. **Slack Messages** (slack-messages.md) — Recent messages from the #data-platform channel. Look for:
    - Technical decisions and recommendations from team members
    - Warnings about data quality, edge cases, or past incidents
    - Commitments or follow-up actions that should be reflected in the PR
    - Context about WHY certain approaches were chosen
 
-2. **Meeting Transcripts** — Read `context/meeting-transcripts.md`. This contains standup and planning meeting notes. Look for:
+2. **Meeting Transcripts** (meeting-transcripts.md) — Standup and planning meeting notes. Look for:
    - Design decisions and trade-offs discussed
    - Action items assigned to specific people
    - Technical constraints or requirements agreed upon verbally
    - Capacity/performance considerations mentioned
 
-3. **Changed Files** — Read the actual model SQL and YAML to verify the implementation matches what was discussed.
+3. **Changed Files** — The diff and full file contents will be in your prompt.
+
+If any context file is NOT in your prompt, read it directly. But normally the orchestrator provides everything.
 
 ## Review Instructions
 
@@ -37,7 +39,9 @@ Synthesise findings from ALL sources above into a single review. Be concise — 
 - **Flag** any warnings or past incidents that apply
 - **Check** if meeting action items were completed
 
-To post: write your review to `/tmp/review-team-knowledge.md`, then run `gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-team-knowledge.md`.
+To post your review:
+1. Use the **Write tool** to write the review to `/tmp/review-team-knowledge.md` — do NOT use echo, printf, cat, or heredocs (markdown with special characters breaks shell escaping)
+2. Use Bash to run: `gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-team-knowledge.md`
 
 ## Review Format
 

--- a/.cortex/agents/pr-reviewer.md
+++ b/.cortex/agents/pr-reviewer.md
@@ -12,37 +12,56 @@ The key value: each agent pulls in context from different places — architectur
 
 ## Workflow
 
-### 1. Gather Context
+### 1. Gather Context (YOU do this, not the sub-agents)
 Run these commands to collect PR information:
 - `gh pr view <number> --repo sfc-gh-yuzheng/ecom-analytics` — PR title, body, linked issues
 - `gh pr diff <number> --repo sfc-gh-yuzheng/ecom-analytics` — changed files
 
 Read the changed model files directly from the repo to get full content.
 
+**CRITICAL — Pre-load ALL context files yourself.** Read every file below and include the full contents in each sub-agent's prompt. Sub-agents running as background tasks cannot reliably read files due to permission constraints. You MUST embed the content directly:
+
+- `context/emails.md` (for Stakeholder agent)
+- `context/slack-messages.md` (for Team Knowledge agent)
+- `context/meeting-transcripts.md` (for Team Knowledge agent)
+- `.cortex/skills/pii-governance/SKILL.md` (for Architecture agent)
+- `.cortex/skills/dbt-conventions/SKILL.md` (for Architecture agent)
+- `.cortex/skills/data-domains/SKILL.md` (for Architecture agent)
+- `dbt_project/macros/mask_pii.sql` (for Architecture agent)
+- All existing YAML schema files in `dbt_project/models/` (for Architecture agent)
+
 ### 2. Launch Three Reviewers in Parallel
-Use the Task tool to spawn all three agents **simultaneously** (in a single message with three Task tool calls). Do NOT use `run_in_background` — foreground subagents have the permissions needed to write files and post `gh` comments. Each agent receives:
+
+Use the Task tool to spawn all three agents **simultaneously** (in a single message with three Task tool calls).
+
+**⚠️ IMPORTANT**: All three agents MUST use `subagent_type: "general-purpose"` — this gives them access to the Write tool, which is required to create the review file. The specialized `pr-reviewer-*` agent types only have Read/Glob/Grep/Bash and CANNOT use Write.
+
+**⚠️ IMPORTANT**: Do NOT use `run_in_background` — foreground subagents have the permissions needed to write files and post `gh` comments. Background agents hit permission errors and fail silently.
+
+Each agent receives in its prompt:
 - The PR number, title, and repo
 - The full diff
 - The full content of changed model files
-- The linked issue number (if any)
-- Instruction to read their specific context files themselves
+- The linked issue body (if any)
+- **The full content of their context files** (pre-loaded by you — NOT file paths for them to read)
+- Their review instructions (copied from their agent .md file)
 - Instruction to post via `gh pr comment`
 
 **Agent 1 — Architecture & Standards** (subagent_type: `general-purpose`)
-- Data sources: Architecture docs (SKILL.md), mask_pii.sql, governance audit trail (Snowflake query), existing model YAML schemas
-- Agent instructions in: `.cortex/agents/pr-reviewer-architecture.md`
+- Context to embed: pii-governance SKILL.md, dbt-conventions SKILL.md, data-domains SKILL.md, mask_pii.sql, existing YAML schemas
+- Review instructions from: `.cortex/agents/pr-reviewer-architecture.md`
 
 **Agent 2 — Stakeholder Communications** (subagent_type: `general-purpose`)
-- Data sources: Stakeholder emails (`context/emails.md`), linked GitHub issue
-- Agent instructions in: `.cortex/agents/pr-reviewer-stakeholder.md`
+- Context to embed: emails.md, linked GitHub issue body
+- Review instructions from: `.cortex/agents/pr-reviewer-stakeholder.md`
 
 **Agent 3 — Team Knowledge** (subagent_type: `general-purpose`)
-- Data sources: Slack messages (`context/slack-messages.md`), meeting transcripts (`context/meeting-transcripts.md`)
-- Agent instructions in: `.cortex/agents/pr-reviewer-team-knowledge.md`
+- Context to embed: slack-messages.md, meeting-transcripts.md
+- Review instructions from: `.cortex/agents/pr-reviewer-team-knowledge.md`
 
 ### 3. Prompt Template for Each Agent
 
-Read the full agent instructions from their `.md` file, then append:
+Read the full agent instructions from their `.md` file, then build the prompt:
 
 ```
 ---
@@ -53,7 +72,7 @@ Review PR #<number> on repo sfc-gh-yuzheng/ecom-analytics.
 
 **PR Title**: <title>
 **PR Body**: <body>
-**Linked Issue**: <if applicable>
+**Linked Issue**: <if applicable, paste the full issue body here>
 
 **Changed files diff**:
 <diff content>
@@ -61,12 +80,18 @@ Review PR #<number> on repo sfc-gh-yuzheng/ecom-analytics.
 **Full content of changed files**:
 <file contents>
 
+**Context files** (pre-loaded — do NOT try to read these yourself):
+<paste the full content of each context file relevant to this agent>
+
 **Instructions**:
-1. Read the context files specified in your "Data Sources to Read" section
+1. Analyze the context provided above against the changed files
 2. Write your review following your exact review format — keep it concise (under 25 lines of markdown)
-3. Write the review body to a temp file, then post:
-   echo '<review>' > /tmp/review-<agent-name>.md
-   gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-<agent-name>.md
+3. Post the review using these exact steps:
+   a. Use the Write tool to write the review to /tmp/review-<agent-name>.md
+   b. Use Bash to run: gh pr comment <number> --repo sfc-gh-yuzheng/ecom-analytics --body-file /tmp/review-<agent-name>.md
+   IMPORTANT: Do NOT use echo, printf, or cat to write the file — the markdown
+   content contains special characters that break shell escaping. Always use
+   the Write tool.
 ```
 
 ### 4. Summarize


### PR DESCRIPTION
## Summary
- Fixes PR review agents that failed to post reviews on first attempt
- Root cause: (1) background agents can't handle permission requests for file reads, (2) writing markdown via bash echo/printf breaks on special characters
- Orchestrator now pre-loads ALL context files into sub-agent prompts so they never need to read files themselves
- All sub-agents now use the Write tool instead of bash for creating review files
- Explicit warnings added against run_in_background and non-general-purpose agent types

## Test plan
- [ ] Run a full PR review cycle: create a test PR, invoke the pr-reviewer orchestrator, verify all 3 reviews post as GitHub comments on first attempt
- [ ] Verify sub-agents receive pre-loaded context (no file read errors in agent output)
- [ ] Verify review files are written via Write tool (no shell escaping errors)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
