### PR TITLE
Add customer lifetime value (CLV) model with segmentation

### DIFF
--- a/dbt_project/models/intermediate/_int_models.yml
+++ b/dbt_project/models/intermediate/_int_models.yml
@@ -22,3 +22,14 @@ models:
           - not_null
       - name: total_amount
         description: "Total payment amount for the order"
+
+  - name: int_customer_payment_methods
+    description: "Preferred payment method per customer, determined by frequency with alphabetical tiebreaker"
+    columns:
+      - name: customer_id
+        description: "Primary key — one row per customer"
+        tests:
+          - unique
+          - not_null
+      - name: preferred_payment_method
+        description: "The payment method used most frequently by the customer. Ties broken alphabetically."

--- a/dbt_project/models/intermediate/int_customer_payment_methods.sql
+++ b/dbt_project/models/intermediate/int_customer_payment_methods.sql
@@ -1,0 +1,35 @@
+with payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payment_method_counts as (
+    select
+        orders.customer_id,
+        payments.payment_method,
+        count(*) as payment_count
+    from payments
+    inner join orders on payments.order_id = orders.order_id
+    group by orders.customer_id, payments.payment_method
+),
+
+ranked as (
+    select
+        customer_id,
+        payment_method,
+        payment_count,
+        row_number() over (
+            partition by customer_id
+            order by payment_count desc, payment_method asc
+        ) as rn
+    from payment_method_counts
+)
+
+select
+    customer_id,
+    payment_method as preferred_payment_method
+from ranked
+where rn = 1

--- a/dbt_project/models/marts/_mart_models.yml
+++ b/dbt_project/models/marts/_mart_models.yml
@@ -26,6 +26,57 @@ models:
         tests:
           - not_null
 
+  - name: fct_customer_lifetime_value
+    description: >
+      Customer lifetime value with 4-tier segmentation for the Q2 retention campaign.
+      Grain: one row per customer. PII columns (email, customer_name) masked via mask_pii().
+      days_since_* and customer_segment are point-in-time values — stale between table builds.
+    columns:
+      - name: customer_id
+        description: "Primary key — unique customer identifier"
+        tests:
+          - unique
+          - not_null
+      - name: customer_name
+        description: "First and last name concatenated. Masked for non-PII_ALLOWED roles."
+        meta:
+          data_classification: "PII - Personal Identifier"
+        tests:
+          - not_null
+      - name: email
+        description: "Customer email address. Masked for non-PII_ALLOWED roles."
+        meta:
+          data_classification: "PII - Personal Identifier"
+        tests:
+          - not_null
+      - name: lifetime_spend
+        description: "Total payment amount across all orders, sourced via int_payment_totals to handle payment dedup."
+        tests:
+          - not_null
+      - name: total_orders
+        description: "Count of distinct orders placed by the customer."
+        tests:
+          - not_null
+      - name: average_order_value
+        description: "Lifetime spend divided by total orders. Zero for customers with no orders."
+        tests:
+          - not_null
+      - name: days_since_first_order
+        description: "Calendar days between first order and today. Stale between builds."
+      - name: days_since_last_order
+        description: "Calendar days between most recent order and today. Stale between builds."
+      - name: customer_segment
+        description: >
+          4-tier classification: VIP (spend >= $500, last order <= 90 days),
+          Regular (spend >= $200, last order <= 90 days),
+          At-Risk (spend >= $200, last order > 90 days),
+          New (spend < $200). At-Risk is the primary retention campaign target.
+        tests:
+          - accepted_values:
+              values: ['VIP', 'Regular', 'At-Risk', 'New']
+      - name: preferred_payment_method
+        description: "Most frequently used payment method across all orders. Ties broken alphabetically."
+
   - name: fct_orders
     description: "Order fact table with payment details"
     columns:

--- a/dbt_project/models/marts/fct_customer_lifetime_value.sql
+++ b/dbt_project/models/marts/fct_customer_lifetime_value.sql
@@ -1,0 +1,61 @@
+with customer_orders as (
+    select * from {{ ref('int_customer_orders') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payment_totals as (
+    select * from {{ ref('int_payment_totals') }}
+),
+
+customer_payment_methods as (
+    select * from {{ ref('int_customer_payment_methods') }}
+),
+
+customer_spend as (
+    select
+        orders.customer_id,
+        sum(payment_totals.total_amount) as lifetime_spend,
+        count(distinct orders.order_id) as total_orders
+    from orders
+    left join payment_totals on orders.order_id = payment_totals.order_id
+    group by orders.customer_id
+),
+
+final as (
+    select
+        customer_orders.customer_id,
+        {{ mask_pii("customer_orders.first_name || ' ' || customer_orders.last_name") }} as customer_name,
+        {{ mask_pii('customer_orders.email') }} as email,
+        coalesce(customer_spend.lifetime_spend, 0) as lifetime_spend,
+        coalesce(customer_spend.total_orders, 0) as total_orders,
+        case
+            when customer_spend.total_orders > 0
+            then customer_spend.lifetime_spend / customer_spend.total_orders
+            else 0
+        end as average_order_value,
+        datediff('day', customer_orders.first_order_date, current_date()) as days_since_first_order,
+        datediff('day', customer_orders.most_recent_order_date, current_date()) as days_since_last_order,
+        case
+            when coalesce(customer_spend.lifetime_spend, 0) >= 500
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+            then 'VIP'
+            when coalesce(customer_spend.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+            then 'Regular'
+            when coalesce(customer_spend.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) > 90
+            then 'At-Risk'
+            else 'New'
+        end as customer_segment,
+        customer_payment_methods.preferred_payment_method
+    from customer_orders
+    left join customer_spend
+        on customer_orders.customer_id = customer_spend.customer_id
+    left join customer_payment_methods
+        on customer_orders.customer_id = customer_payment_methods.customer_id
+)
+
+select * from final


### PR DESCRIPTION
## Summary
- Adds `fct_customer_lifetime_value` mart model with CLV metrics (lifetime spend, total orders, AOV, recency) and 4-tier customer segmentation (VIP/Regular/At-Risk/New) for the Q2 retention campaign
- Adds `int_customer_payment_methods` intermediate model deriving preferred payment method by frequency (ROW_NUMBER with alphabetical tiebreaker)
- PII columns (`email`, `customer_name`) masked via `mask_pii()` with `data_classification` meta tags per governance requirements

## Test plan
- [ ] Verify `dbt build` succeeds for new models and all schema tests pass
- [ ] Confirm `customer_segment` values match threshold logic (VIP >= $500 + 90d, Regular >= $200 + 90d, At-Risk >= $200 + >90d, New < $200)
- [ ] Validate spend flows through `int_payment_totals` (not directly from `stg_payments`) to avoid Q4 payment dedup issue
- [ ] Check PII masking works correctly for non-PII_ALLOWED roles
- [ ] Verify preferred_payment_method is frequency-based with deterministic tiebreaker

Closes #1

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)