### PR TITLE
Add customer lifetime value (CLV) model with segmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ dbt_project/profiles.yml
 
 # Environment
 .env
+.venv/
+
+# dbt user config
+dbt_project/.user.yml

--- a/dbt_project/models/intermediate/_int_models.yml
+++ b/dbt_project/models/intermediate/_int_models.yml
@@ -22,3 +22,14 @@ models:
           - not_null
       - name: total_amount
         description: "Total payment amount for the order"
+
+  - name: int_customer_payment_methods
+    description: "Preferred payment method per customer, derived from most frequently used payment method across all orders. Ties broken alphabetically."
+    columns:
+      - name: customer_id
+        description: "Primary key"
+        tests:
+          - unique
+          - not_null
+      - name: preferred_payment_method
+        description: "The payment method used most frequently by the customer. Ties broken alphabetically (ASC)."

--- a/dbt_project/models/intermediate/int_customer_payment_methods.sql
+++ b/dbt_project/models/intermediate/int_customer_payment_methods.sql
@@ -1,0 +1,35 @@
+with payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payment_method_counts as (
+    select
+        orders.customer_id,
+        payments.payment_method,
+        count(*) as payment_count
+    from payments
+    inner join orders on payments.order_id = orders.order_id
+    group by orders.customer_id, payments.payment_method
+),
+
+ranked as (
+    select
+        customer_id,
+        payment_method,
+        payment_count,
+        row_number() over (
+            partition by customer_id
+            order by payment_count desc, payment_method asc
+        ) as rn
+    from payment_method_counts
+)
+
+select
+    customer_id,
+    payment_method as preferred_payment_method
+from ranked
+where rn = 1

--- a/dbt_project/models/marts/_mart_models.yml
+++ b/dbt_project/models/marts/_mart_models.yml
@@ -49,4 +49,61 @@ models:
         description: "Order status"
         tests:
           - accepted_values:
-              values: ['placed', 'shipped', 'completed', 'returned']
+              arguments:
+                values: ['placed', 'shipped', 'completed', 'returned']
+
+  - name: fct_customer_lifetime_value
+    description: >
+      Customer lifetime value with 4-tier segmentation for Marketing retention campaigns.
+      Grain: one row per customer. PII columns (email, customer_name) masked via mask_pii()
+      for non-PII_ALLOWED roles. days_since_* and customer_segment columns are point-in-time
+      values computed at build time — they become stale between dbt runs.
+    columns:
+      - name: customer_id
+        description: "Primary key — unique customer identifier"
+        tests:
+          - unique
+          - not_null
+      - name: customer_name
+        description: "First and last name concatenated. Masked for non-PII_ALLOWED roles."
+        config:
+          meta:
+            data_classification: "PII - Personal Identifier"
+        tests:
+          - not_null
+      - name: email
+        description: "Customer email address. Masked for non-PII_ALLOWED roles."
+        config:
+          meta:
+            data_classification: "PII - Personal Identifier"
+        tests:
+          - not_null
+      - name: lifetime_spend
+        description: "Total payment amount across all orders. Sourced through int_payment_totals to handle Q4 payment dedup."
+        tests:
+          - not_null
+      - name: total_orders
+        description: "Count of distinct orders placed by the customer."
+        tests:
+          - not_null
+      - name: average_order_value
+        description: "Lifetime spend divided by total orders. Zero for customers with no orders."
+        tests:
+          - not_null
+      - name: days_since_first_order
+        description: "Calendar days between the customer's first order and today. Stale between builds."
+      - name: days_since_last_order
+        description: "Calendar days between the customer's most recent order and today. Stale between builds."
+      - name: preferred_payment_method
+        description: "The payment method used most frequently across all orders. Ties broken alphabetically."
+      - name: customer_segment
+        description: >
+          4-tier segmentation: VIP (spend >= $500, ordered within 90 days),
+          Regular (spend >= $200, ordered within 90 days),
+          At-Risk (spend >= $200, no orders in 90 days),
+          New (spend < $200). Evaluated in priority order — first match wins.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['VIP', 'Regular', 'At-Risk', 'New']

--- a/dbt_project/models/marts/fct_customer_lifetime_value.sql
+++ b/dbt_project/models/marts/fct_customer_lifetime_value.sql
@@ -1,0 +1,59 @@
+with customer_orders as (
+    select * from {{ ref('int_customer_orders') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payment_totals as (
+    select * from {{ ref('int_payment_totals') }}
+),
+
+customer_spend as (
+    select
+        orders.customer_id,
+        sum(payment_totals.total_amount) as lifetime_spend,
+        count(distinct orders.order_id) as total_orders
+    from orders
+    left join payment_totals on orders.order_id = payment_totals.order_id
+    group by orders.customer_id
+),
+
+customer_payment_methods as (
+    select * from {{ ref('int_customer_payment_methods') }}
+),
+
+final as (
+    select
+        customer_orders.customer_id,
+        {{ mask_pii("customer_orders.first_name || ' ' || customer_orders.last_name") }} as customer_name,
+        {{ mask_pii('customer_orders.email') }} as email,
+        coalesce(customer_spend.lifetime_spend, 0) as lifetime_spend,
+        coalesce(customer_spend.total_orders, 0) as total_orders,
+        case
+            when coalesce(customer_spend.total_orders, 0) > 0
+            then coalesce(customer_spend.lifetime_spend, 0) / customer_spend.total_orders
+            else 0
+        end as average_order_value,
+        datediff('day', customer_orders.first_order_date, current_date()) as days_since_first_order,
+        datediff('day', customer_orders.most_recent_order_date, current_date()) as days_since_last_order,
+        customer_payment_methods.preferred_payment_method,
+        case
+            when coalesce(customer_spend.lifetime_spend, 0) >= 500
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+            then 'VIP'
+            when coalesce(customer_spend.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) <= 90
+            then 'Regular'
+            when coalesce(customer_spend.lifetime_spend, 0) >= 200
+                and datediff('day', customer_orders.most_recent_order_date, current_date()) > 90
+            then 'At-Risk'
+            else 'New'
+        end as customer_segment
+    from customer_orders
+    left join customer_spend on customer_orders.customer_id = customer_spend.customer_id
+    left join customer_payment_methods on customer_orders.customer_id = customer_payment_methods.customer_id
+)
+
+select * from final


### PR DESCRIPTION
## Summary
- Adds `fct_customer_lifetime_value` mart model with 4-tier customer segmentation (VIP, Regular, At-Risk, New) for Marketing's Q2 retention campaign
- Adds `int_customer_payment_methods` intermediate model deriving preferred payment method via frequency-based ranking with deterministic tiebreaker
- PII columns (email, customer_name) masked via `mask_pii()` with `data_classification` meta tags for governance scanning
- Spend routed through `int_payment_totals` to handle Q4 payment dedup; order count uses `COUNT(DISTINCT order_id)`

## Scope decisions
- **Stretch goals skipped for v1**: `first_order_channel` (Lisa's email,  boolean (Lisa's follow-up) — not in issue acceptance criteria
- **Hardcoded thresholds**: Confirmed acceptable for v1 by Lisa/Rebecca — configurable thresholds flagged as future improvement

## Test plan
- [ ]  passes (models + 12 schema tests)
- [ ] Verify  values: VIP (spend >= 00, recency <= 90d), Regular (>= 00, <= 90d), At-Risk (>= 00, > 90d), New (< 00)
- [ ] Verify  picks most frequent (not lexicographic MAX)
- [ ] Verify PII masking:  and  show masked values without  role
- [ ] Verify  returns 0 for zero-order customers (no division by zero)
- [ ] Governance audit trail shows no unmasked PII violations

Closes #1

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)
PREOF
)